### PR TITLE
Update to allow newer version of node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "loader-utils": "^0.2.5",
-    "node-sass": "^1.2.2",
+    "node-sass": "^2.0.0",
     "sass-graph": "git+https://github.com/lox/sass-graph.git#3a17328"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "loader-utils": "^0.2.5",
-    "node-sass": "^2.0.0",
+    "node-sass": "^3.0.0",
     "sass-graph": "git+https://github.com/lox/sass-graph.git#3a17328"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes installing sass-loader-sync on a windows machine with x64 especially Windows 8 machine.
